### PR TITLE
Add Bicep-Infra scaffold, CI validation workflow, and local validation script

### DIFF
--- a/Bicep-Infra/.github/workflows/validate-bicep.yml
+++ b/Bicep-Infra/.github/workflows/validate-bicep.yml
@@ -1,0 +1,40 @@
+name: Validate Bicep
+
+on:
+  pull_request:
+    paths:
+      - 'Bicep-Infra/**'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure CLI login (optional)
+        if: false # enable once CI/CD decision (GitHub/Azure DevOps) is finalized
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Bicep build
+        run: az bicep build --file Bicep-Infra/main.bicep
+
+      - name: Validate parameters JSON format
+        run: |
+          python -m json.tool Bicep-Infra/main.parameters.json >/dev/null
+          python -m json.tool Bicep-Infra/environments/dev/main.parameters.json >/dev/null
+          python -m json.tool Bicep-Infra/environments/qa/main.parameters.json >/dev/null
+          python -m json.tool Bicep-Infra/environments/uat/main.parameters.json >/dev/null
+          python -m json.tool Bicep-Infra/environments/prod/main.parameters.json >/dev/null
+
+      - name: Validate logicApps array not empty
+        run: |
+          jq '.parameters.logicApps.value | length > 0' Bicep-Infra/environments/dev/main.parameters.json
+          jq '.parameters.logicApps.value | length > 0' Bicep-Infra/environments/qa/main.parameters.json
+          jq '.parameters.logicApps.value | length > 0' Bicep-Infra/environments/uat/main.parameters.json
+          jq '.parameters.logicApps.value | length > 0' Bicep-Infra/environments/prod/main.parameters.json

--- a/Bicep-Infra/BRANCHING.md
+++ b/Bicep-Infra/BRANCHING.md
@@ -1,0 +1,14 @@
+# Branching recommendation
+
+As requested, use `Develop` as the integration branch for infrastructure changes.
+
+- `main` → production-ready, tagged releases.
+- `Develop` → default branch for active infra development.
+- `feature/*` → short-lived feature branches merged into `Develop`.
+- `release/*` (optional) → hardening before merge to `main`.
+
+Typical flow:
+1. Create `feature/logicapp-<name>` from `Develop`.
+2. Add/update entries in `environments/<env>/main.parameters.json`.
+3. Open PR to `Develop`.
+4. Promote from `Develop` to `main` when validated.

--- a/Bicep-Infra/README.md
+++ b/Bicep-Infra/README.md
@@ -1,0 +1,89 @@
+# Bicep-Infra
+
+Enterprise starter scaffold for **Azure Logic App Standard** using Bicep with reusable parameter-only deployments.
+
+## Confirmed standards implemented
+- **Subscription model**:
+  - Lower environments (`dev`, `qa`, `uat`) deploy to a **lower subscription**.
+  - `prod` deploys to a **production subscription**.
+- **Resource group naming**: `RG-AG-<environment>`.
+- **Region**: all environments standardized to `eastus`.
+- **Sizing/HA baseline**: basic baseline (`WS1`, 1 worker) for all envs.
+- **Networking**: VNet integration + Private Endpoint pattern.
+- **Secrets**: Key Vault reference pattern.
+- **Monitoring**: App Insights workspace-based + metric alert baseline.
+- **Workflow source strategy**: monorepo.
+
+## Folder structure
+
+```text
+Bicep-Infra/
+├── main.bicep
+├── main.parameters.json
+├── modules/
+│   └── logic-app-standard.bicep
+├── environments/
+│   ├── dev/main.parameters.json
+│   ├── qa/main.parameters.json
+│   ├── uat/main.parameters.json
+│   └── prod/main.parameters.json
+├── workflows/
+│   └── sample.workflow.json
+├── docs/
+│   └── deployment-model.md
+└── .github/workflows/
+    └── validate-bicep.yml
+```
+
+## Scale model (easy to add more Logic Apps)
+Add new entries under `logicApps` array in any environment parameter file:
+
+```json
+"logicApps": {
+  "value": [
+    {
+      "name": "la-std-qa-orders",
+      "appServicePlanName": "asp-la-qa-shared",
+      "storageAccountName": "stlaqashared01",
+      "appInsightsName": "appi-la-qa-orders",
+      "skuName": "WS1",
+      "workerSize": 0,
+      "workerCount": 1
+    },
+    {
+      "name": "la-std-qa-billing",
+      "appServicePlanName": "asp-la-qa-shared",
+      "storageAccountName": "stlaqabilling01",
+      "appInsightsName": "appi-la-qa-billing",
+      "skuName": "WS1",
+      "workerSize": 0,
+      "workerCount": 1
+    }
+  ]
+}
+```
+
+## Deployment examples
+
+Lower subscription (dev/qa/uat):
+```bash
+az account set --subscription <LOWER_SUBSCRIPTION_ID>
+az deployment sub create \
+  --location eastus \
+  --template-file main.bicep \
+  --parameters @environments/qa/main.parameters.json
+```
+
+Production subscription:
+```bash
+az account set --subscription <PROD_SUBSCRIPTION_ID>
+az deployment sub create \
+  --location eastus \
+  --template-file main.bicep \
+  --parameters @environments/prod/main.parameters.json
+```
+
+## Validation
+```bash
+az bicep build --file main.bicep
+```

--- a/Bicep-Infra/docs/deployment-model.md
+++ b/Bicep-Infra/docs/deployment-model.md
@@ -1,0 +1,25 @@
+# Deployment model
+
+## Subscription segmentation
+- Lower environments: `dev`, `qa`, `uat` in lower subscription.
+- Production environment: `prod` in production subscription.
+
+## Naming standards
+- Resource Group: `RG-AG-<environment>`
+
+## Region standard
+- `eastus` for all environments.
+
+## Network/Security baseline
+- Logic App Standard integrated with delegated subnet.
+- Private endpoint created for each Logic App site.
+- Public network access disabled at app level.
+- Storage account locked with VNet ACLs.
+
+## Secrets and configuration
+- Key Vault is modeled as an existing resource and exposed to app settings with `KeyVaultUri`.
+- Extend with managed identity access policy / RBAC assignments per organization policy.
+
+## Monitoring and alerting
+- App Insights is workspace-based (Log Analytics).
+- Baseline metric alert added for `Http5xx` > 0.

--- a/Bicep-Infra/environments/dev/main.parameters.json
+++ b/Bicep-Infra/environments/dev/main.parameters.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    },
+    "environment": {
+      "value": "dev"
+    },
+    "resourceGroupName": {
+      "value": "RG-AG-dev"
+    },
+    "tags": {
+      "value": {
+        "environment": "dev",
+        "costCenter": "CC-1001",
+        "dataClassification": "Internal",
+        "owner": "integration-team",
+        "managedBy": "bicep"
+      }
+    },
+    "vnetName": {
+      "value": "vnet-ag-eastus-shared"
+    },
+    "integrationSubnetName": {
+      "value": "snet-logicapp-integration"
+    },
+    "privateEndpointSubnetName": {
+      "value": "snet-private-endpoints"
+    },
+    "logAnalyticsWorkspaceName": {
+      "value": "law-ag-dev-eastus"
+    },
+    "keyVaultName": {
+      "value": "kvagdev001"
+    },
+    "logicApps": {
+      "value": [
+        {
+          "name": "la-std-dev-orders",
+          "appServicePlanName": "asp-la-dev-shared",
+          "storageAccountName": "stladevshared01",
+          "appInsightsName": "appi-la-dev-orders",
+          "skuName": "WS1",
+          "workerSize": 0,
+          "workerCount": 1,
+          "tags": {
+            "domain": "orders"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Bicep-Infra/environments/prod/main.parameters.json
+++ b/Bicep-Infra/environments/prod/main.parameters.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    },
+    "environment": {
+      "value": "prod"
+    },
+    "resourceGroupName": {
+      "value": "RG-AG-prod"
+    },
+    "tags": {
+      "value": {
+        "environment": "prod",
+        "costCenter": "CC-1001",
+        "dataClassification": "Confidential",
+        "owner": "integration-team",
+        "managedBy": "bicep"
+      }
+    },
+    "vnetName": {
+      "value": "vnet-ag-eastus-prod"
+    },
+    "integrationSubnetName": {
+      "value": "snet-logicapp-integration"
+    },
+    "privateEndpointSubnetName": {
+      "value": "snet-private-endpoints"
+    },
+    "logAnalyticsWorkspaceName": {
+      "value": "law-ag-prod-eastus"
+    },
+    "keyVaultName": {
+      "value": "kvagprod001"
+    },
+    "logicApps": {
+      "value": [
+        {
+          "name": "la-std-prod-orders",
+          "appServicePlanName": "asp-la-prod-shared",
+          "storageAccountName": "stlaprodshared01",
+          "appInsightsName": "appi-la-prod-orders",
+          "skuName": "WS1",
+          "workerSize": 0,
+          "workerCount": 1
+        }
+      ]
+    }
+  }
+}

--- a/Bicep-Infra/environments/qa/main.parameters.json
+++ b/Bicep-Infra/environments/qa/main.parameters.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    },
+    "environment": {
+      "value": "qa"
+    },
+    "resourceGroupName": {
+      "value": "RG-AG-qa"
+    },
+    "tags": {
+      "value": {
+        "environment": "qa",
+        "costCenter": "CC-1001",
+        "dataClassification": "Internal",
+        "owner": "integration-team",
+        "managedBy": "bicep"
+      }
+    },
+    "vnetName": {
+      "value": "vnet-ag-eastus-shared"
+    },
+    "integrationSubnetName": {
+      "value": "snet-logicapp-integration"
+    },
+    "privateEndpointSubnetName": {
+      "value": "snet-private-endpoints"
+    },
+    "logAnalyticsWorkspaceName": {
+      "value": "law-ag-qa-eastus"
+    },
+    "keyVaultName": {
+      "value": "kvagqa001"
+    },
+    "logicApps": {
+      "value": [
+        {
+          "name": "la-std-qa-orders",
+          "appServicePlanName": "asp-la-qa-shared",
+          "storageAccountName": "stlaqashared01",
+          "appInsightsName": "appi-la-qa-orders",
+          "skuName": "WS1",
+          "workerSize": 0,
+          "workerCount": 1
+        }
+      ]
+    }
+  }
+}

--- a/Bicep-Infra/environments/uat/main.parameters.json
+++ b/Bicep-Infra/environments/uat/main.parameters.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    },
+    "environment": {
+      "value": "uat"
+    },
+    "resourceGroupName": {
+      "value": "RG-AG-uat"
+    },
+    "tags": {
+      "value": {
+        "environment": "uat",
+        "costCenter": "CC-1001",
+        "dataClassification": "Internal",
+        "owner": "integration-team",
+        "managedBy": "bicep"
+      }
+    },
+    "vnetName": {
+      "value": "vnet-ag-eastus-shared"
+    },
+    "integrationSubnetName": {
+      "value": "snet-logicapp-integration"
+    },
+    "privateEndpointSubnetName": {
+      "value": "snet-private-endpoints"
+    },
+    "logAnalyticsWorkspaceName": {
+      "value": "law-ag-uat-eastus"
+    },
+    "keyVaultName": {
+      "value": "kvaguat001"
+    },
+    "logicApps": {
+      "value": [
+        {
+          "name": "la-std-uat-orders",
+          "appServicePlanName": "asp-la-uat-shared",
+          "storageAccountName": "stlauatshared01",
+          "appInsightsName": "appi-la-uat-orders",
+          "skuName": "WS1",
+          "workerSize": 0,
+          "workerCount": 1
+        }
+      ]
+    }
+  }
+}

--- a/Bicep-Infra/main.bicep
+++ b/Bicep-Infra/main.bicep
@@ -1,0 +1,65 @@
+targetScope = 'subscription'
+
+@description('Primary deployment location (standardized to East US)')
+param location string = 'eastus'
+
+@description('Environment short name: dev, qa, uat, prod')
+@allowed([
+  'dev'
+  'qa'
+  'uat'
+  'prod'
+])
+param environment string
+
+@description('Resource group name. Convention: RG-AG-<environment>')
+param resourceGroupName string
+
+@description('Tags applied to all resources')
+param tags object = {}
+
+@description('Array of Logic App Standard definitions for this environment')
+param logicApps array
+
+@description('Shared virtual network name for Logic App integration')
+param vnetName string
+
+@description('Subnet name delegated for Logic App integration')
+param integrationSubnetName string
+
+@description('Private endpoint subnet name')
+param privateEndpointSubnetName string
+
+@description('Log Analytics workspace name')
+param logAnalyticsWorkspaceName string
+
+@description('Key Vault name for secrets and references')
+param keyVaultName string
+
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+  name: resourceGroupName
+  location: location
+  tags: tags
+}
+
+module logicAppModules 'modules/logic-app-standard.bicep' = [for app in logicApps: {
+  name: 'la-${environment}-${app.name}'
+  scope: rg
+  params: {
+    location: location
+    environment: environment
+    logicAppName: app.name
+    appServicePlanName: app.appServicePlanName
+    storageAccountName: app.storageAccountName
+    appInsightsName: app.appInsightsName
+    skuName: app.skuName
+    workerSize: app.workerSize
+    workerCount: app.workerCount
+    vnetName: vnetName
+    integrationSubnetName: integrationSubnetName
+    privateEndpointSubnetName: privateEndpointSubnetName
+    keyVaultName: keyVaultName
+    logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
+    tags: union(tags, app.tags ?? {})
+  }
+}]

--- a/Bicep-Infra/main.parameters.json
+++ b/Bicep-Infra/main.parameters.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "value": "eastus"
+    },
+    "environment": {
+      "value": "dev"
+    },
+    "resourceGroupName": {
+      "value": "RG-AG-dev"
+    },
+    "tags": {
+      "value": {
+        "environment": "dev",
+        "costCenter": "CC-1001",
+        "dataClassification": "Internal",
+        "owner": "integration-team",
+        "managedBy": "bicep"
+      }
+    },
+    "vnetName": {
+      "value": "vnet-ag-eastus-shared"
+    },
+    "integrationSubnetName": {
+      "value": "snet-logicapp-integration"
+    },
+    "privateEndpointSubnetName": {
+      "value": "snet-private-endpoints"
+    },
+    "logAnalyticsWorkspaceName": {
+      "value": "law-ag-dev-eastus"
+    },
+    "keyVaultName": {
+      "value": "kvagdev001"
+    },
+    "logicApps": {
+      "value": [
+        {
+          "name": "la-std-dev-orders",
+          "appServicePlanName": "asp-la-dev-shared",
+          "storageAccountName": "stladevshared01",
+          "appInsightsName": "appi-la-dev-orders",
+          "skuName": "WS1",
+          "workerSize": 0,
+          "workerCount": 1
+        }
+      ]
+    }
+  }
+}

--- a/Bicep-Infra/modules/logic-app-standard.bicep
+++ b/Bicep-Infra/modules/logic-app-standard.bicep
@@ -1,0 +1,238 @@
+targetScope = 'resourceGroup'
+
+@description('Azure region')
+param location string = 'eastus'
+
+@description('Environment name')
+param environment string
+
+@description('Logic App Standard site name')
+param logicAppName string
+
+@description('App Service plan name used by Logic App Standard')
+param appServicePlanName string
+
+@description('Storage account name for workflow runtime')
+param storageAccountName string
+
+@description('Application Insights name')
+param appInsightsName string
+
+@description('App Service plan SKU name. Basic baseline uses WS1')
+param skuName string = 'WS1'
+
+@description('Worker size (0 = small, 1 = medium, 2 = large)')
+param workerSize int = 0
+
+@description('Worker count')
+param workerCount int = 1
+
+@description('Existing VNet name used for integration and private endpoints')
+param vnetName string
+
+@description('Existing subnet delegated for Logic App VNet integration')
+param integrationSubnetName string
+
+@description('Existing subnet for private endpoint')
+param privateEndpointSubnetName string
+
+@description('Existing Key Vault name for app settings/secret references')
+param keyVaultName string
+
+@description('Log Analytics workspace name for monitoring')
+param logAnalyticsWorkspaceName string
+
+@description('Resource tags')
+param tags object = {}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2023-09-01' existing = {
+  name: vnetName
+}
+
+resource integrationSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
+  name: integrationSubnetName
+  parent: vnet
+}
+
+resource peSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-09-01' existing = {
+  name: privateEndpointSubnetName
+  parent: vnet
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource law 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  tags: tags
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    allowBlobPublicAccess: false
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+      virtualNetworkRules: [
+        {
+          id: integrationSubnet.id
+          action: 'Allow'
+        }
+      ]
+      ipRules: []
+    }
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  tags: tags
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: law.id
+    IngestionMode: 'LogAnalytics'
+  }
+}
+
+resource servicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: appServicePlanName
+  location: location
+  kind: 'elastic'
+  sku: {
+    name: skuName
+    tier: 'WorkflowStandard'
+    size: skuName
+    capacity: workerCount
+  }
+  tags: tags
+  properties: {
+    perSiteScaling: false
+    elasticScaleEnabled: false
+    maximumElasticWorkerCount: 1
+    workerSize: workerSize
+    workerSizeId: workerSize
+  }
+}
+
+resource logicApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: logicAppName
+  location: location
+  kind: 'functionapp,workflowapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  tags: tags
+  properties: {
+    serverFarmId: servicePlan.id
+    httpsOnly: true
+    virtualNetworkSubnetId: integrationSubnet.id
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'APP_KIND'
+          value: 'workflowApp'
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'node'
+        }
+        {
+          name: 'WEBSITE_NODE_DEFAULT_VERSION'
+          value: '~18'
+        }
+        {
+          name: 'WEBSITE_VNET_ROUTE_ALL'
+          value: '1'
+        }
+        {
+          name: 'AzureWebJobsStorage'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${storage.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsights.properties.ConnectionString
+        }
+        {
+          name: 'WORKFLOWS_TENANT_ID'
+          value: subscription().tenantId
+        }
+        {
+          name: 'KeyVaultUri'
+          value: keyVault.properties.vaultUri
+        }
+      ]
+      ftpsState: 'Disabled'
+      minTlsVersion: '1.2'
+      publicNetworkAccess: 'Disabled'
+    }
+  }
+}
+
+resource logicAppPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-09-01' = {
+  name: 'pe-${logicAppName}'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: peSubnet.id
+    }
+    privateLinkServiceConnections: [
+      {
+        name: 'pls-${logicAppName}'
+        properties: {
+          privateLinkServiceId: logicApp.id
+          groupIds: [
+            'sites'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource metricAlert 'Microsoft.Insights/metricAlerts@2018-03-01' = {
+  name: 'ma-${logicAppName}-servererrors'
+  location: 'global'
+  tags: tags
+  properties: {
+    description: 'Alert on Logic App HTTP 5xx count'
+    severity: 2
+    enabled: true
+    scopes: [
+      logicApp.id
+    ]
+    evaluationFrequency: 'PT5M'
+    windowSize: 'PT5M'
+    criteria: {
+      'odata.type': 'Microsoft.Azure.Monitor.SingleResourceMultipleMetricCriteria'
+      allOf: [
+        {
+          name: 'http5xx'
+          metricName: 'Http5xx'
+          metricNamespace: 'microsoft.web/sites'
+          operator: 'GreaterThan'
+          threshold: 0
+          timeAggregation: 'Total'
+          criterionType: 'StaticThresholdCriterion'
+        }
+      ]
+    }
+  }
+}
+
+output logicAppResourceId string = logicApp.id

--- a/Bicep-Infra/workflows/sample.workflow.json
+++ b/Bicep-Infra/workflows/sample.workflow.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2019-05-01/workflowdefinition.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "triggers": {
+    "manual": {
+      "type": "Request",
+      "kind": "Http",
+      "inputs": {
+        "schema": {}
+      }
+    }
+  },
+  "actions": {
+    "response": {
+      "type": "Response",
+      "kind": "Http",
+      "inputs": {
+        "statusCode": 200,
+        "body": {
+          "message": "Logic App Standard workflow scaffold deployed via Bicep"
+        }
+      },
+      "runAfter": {}
+    }
+  },
+  "outputs": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Java-application
-This Repository contains Java application with different branches.
+This repository contains a Java web application with different branches.
+
+## Validation
+Run local validation checks with:
+
+```bash
+./scripts/validate.sh
+```
+
+The script verifies XML files, confirms the JSP entrypoint exists, and then attempts `mvn test` as a best-effort step.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[1/3] Checking XML files are well-formed..."
+python - <<'PY'
+import pathlib
+import xml.etree.ElementTree as ET
+
+xml_files = [
+    pathlib.Path('pom.xml'),
+    pathlib.Path('src/main/webapp/WEB-INF/web.xml'),
+]
+
+for path in xml_files:
+    ET.parse(path)
+    print(f"  OK: {path}")
+PY
+
+echo "[2/3] Checking JSP entrypoint exists and is non-empty..."
+if [[ ! -s src/main/webapp/index.jsp ]]; then
+  echo "index.jsp is missing or empty" >&2
+  exit 1
+fi
+echo "  OK: src/main/webapp/index.jsp"
+
+echo "[3/3] Maven test run (best effort)..."
+if mvn test -q; then
+  echo "  OK: mvn test"
+else
+  echo "  WARN: mvn test could not complete in this environment (likely blocked dependency downloads)." >&2
+fi


### PR DESCRIPTION
### Motivation

- Provide an enterprise starter scaffold for Azure Logic App Standard using Bicep and reusable parameter-driven deployments. 
- Add automated and local validation to prevent malformed templates/parameters and to enforce a minimal parameter structure for environments.
- Document branching and deployment guidance for infra teams.

### Description

- Add a new `Bicep-Infra/` scaffold including `main.bicep`, `modules/logic-app-standard.bicep`, environment parameter files under `environments/{dev,qa,uat,prod}/main.parameters.json`, `main.parameters.json`, a sample workflow `workflows/sample.workflow.json`, and documentation (`README.md`, `docs/deployment-model.md`, `BRANCHING.md`).
- Add a GitHub Actions workflow `Bicep-Infra/.github/workflows/validate-bicep.yml` to run `az bicep build`, validate JSON parameter files with `python -m json.tool`, and check that the `logicApps` arrays are non-empty using `jq` on pull requests touching `Bicep-Infra/**`.
- Add a local validation helper `scripts/validate.sh` that checks XML well-formedness, verifies `src/main/webapp/index.jsp` exists and is non-empty, and performs a best-effort `mvn test` run.
- Update repository `README.md` to document local validation via `./scripts/validate.sh`.

### Testing

- No automated tests were executed as part of this PR merge; CI workflow is added but not yet run on this change.
- The new CI job `Bicep-Infra/.github/workflows/validate-bicep.yml` is configured to run `az bicep build` and JSON/`jq` validations on future pull requests and will report pass/fail in CI.
- The `scripts/validate.sh` script provides local automated checks (XML parse, index.jsp presence, and best-effort `mvn test`) intended for developers to run prior to opening PRs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a096f0107c832aa625e67e85183c0f)